### PR TITLE
Update uploader.php

### DIFF
--- a/core/uploader.php
+++ b/core/uploader.php
@@ -141,7 +141,7 @@ class uploader {
             ini_set('session.cookie_domain', $_CONFIG['_sessionDomain']);
         switch ($this->cms) {
             case "drupal": break;
-            default: session_start(); break;
+            default: if (!session_id()) session_start(); break;
         }
 
         // RELOAD DEFAULT CONFIGURATION


### PR DESCRIPTION
Prevents "warning: session_start() [function.session-start]: Cannot send session cache limiter - headers already sent (output started at ...\core\uploader.php on line 144" if session already started.
