### PR TITLE
kcfinder\session class added

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -123,4 +123,4 @@ $_CONFIG = array(
 
 );
 
-?>
+return $_CONFIG;

--- a/core/autoload.php
+++ b/core/autoload.php
@@ -28,8 +28,8 @@ spl_autoload_register(function($path) {
             require "core/class/browser.php";
         elseif ($class == "minifier")
             require "core/class/minifier.php";
-		elseif ($class == "session")
-			require "core/class/session.php";
+        elseif ($class == "session")
+            require "core/class/session.php";
 
         elseif (file_exists("core/types/$class.php"))
             require "core/types/$class.php";

--- a/core/autoload.php
+++ b/core/autoload.php
@@ -28,6 +28,8 @@ spl_autoload_register(function($path) {
             require "core/class/browser.php";
         elseif ($class == "minifier")
             require "core/class/minifier.php";
+		elseif ($class == "session")
+			require "core/class/session.php";
 
         elseif (file_exists("core/types/$class.php"))
             require "core/types/$class.php";

--- a/core/class/session.php
+++ b/core/class/session.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace kcfinder;
+
+class session
+{
+
+	const SESSION_VAR = '_sessionVar';
+
+	/** @var array */
+	private $config;
+
+	/** @var array|\Traversable */
+	private $session;
+
+	public function __construct(array $config)
+	{
+		$this->config = $config;
+		$this->initSession();
+		$this->initConfig();
+	}
+
+	/**
+	 * @return array
+	 */
+	public function & getSession()
+	{
+		return $this->session;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function & getConfig()
+	{
+		return $this->config;
+	}
+
+	/***/
+	private function initSession()
+	{
+		if (isset($this->config[self::SESSION_VAR])) {
+			$session = & $this->config[self::SESSION_VAR];
+
+			if (!is_array($session) && !$session instanceof \Traversable) {
+				$session = $this->getDefaultSession()[$session];
+
+				if (!is_array($session)) {
+					$session = array();
+				}
+			}
+		} else {
+			$session = $this->getDefaultSession();
+		}
+
+		$this->session = & $session;
+	}
+
+	/**
+	 * @return array
+	 */
+	private function & getDefaultSession()
+	{
+		// start default
+		if (!session_id()) {
+			if (isset($this->config['_sessionLifetime'])) {
+				ini_set('session.gc_maxlifetime', $this->config['_sessionLifetime'] * 60);
+			}
+
+			if (isset($this->config['_sessionDir'])) {
+				ini_set('session.save_path', $this->config['_sessionDir']);
+			}
+
+			if (isset($this->config['_sessionDomain'])) {
+				ini_set('session.cookie_domain', $this->config['_sessionDomain']);
+			}
+
+			session_start();
+		}
+
+		return $_SESSION;
+	}
+
+	/***/
+	private function initConfig()
+	{
+		foreach ($this->session as $key => $val) {
+			if ((substr($key, 0, 1) != "_") && isset($this->config[$key])) {
+				$this->config[$key] = $val;
+			}
+		}
+	}
+
+}

--- a/core/class/session.php
+++ b/core/class/session.php
@@ -5,90 +5,90 @@ namespace kcfinder;
 class session
 {
 
-	const SESSION_VAR = '_sessionVar';
+    const SESSION_VAR = '_sessionVar';
 
-	/** @var array */
-	private $config;
+    /** @var array */
+    private $config;
 
-	/** @var array|\Traversable */
-	private $session;
+    /** @var array|\Traversable */
+    private $session;
 
-	public function __construct(array $config)
-	{
-		$this->config = $config;
-		$this->initSession();
-		$this->initConfig();
-	}
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+        $this->initSession();
+        $this->initConfig();
+    }
 
-	/**
-	 * @return array
-	 */
-	public function & getSession()
-	{
-		return $this->session;
-	}
+    /**
+     * @return array
+     */
+    public function & getSession()
+    {
+        return $this->session;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function & getConfig()
-	{
-		return $this->config;
-	}
+    /**
+     * @return array
+     */
+    public function & getConfig()
+    {
+        return $this->config;
+    }
 
-	/***/
-	private function initSession()
-	{
-		if (isset($this->config[self::SESSION_VAR])) {
-			$session = & $this->config[self::SESSION_VAR];
+    /***/
+    private function initSession()
+    {
+        if (isset($this->config[self::SESSION_VAR])) {
+            $session = & $this->config[self::SESSION_VAR];
 
-			if (!is_array($session) && !$session instanceof \Traversable) {
-				$session = $this->getDefaultSession()[$session];
+            if (!is_array($session) && !$session instanceof \Traversable) {
+                $session = $this->getDefaultSession()[$session];
 
-				if (!is_array($session)) {
-					$session = array();
-				}
-			}
-		} else {
-			$session = $this->getDefaultSession();
-		}
+                if (!is_array($session)) {
+                    $session = array();
+                }
+            }
+        } else {
+            $session = $this->getDefaultSession();
+        }
 
-		$this->session = & $session;
-	}
+        $this->session = & $session;
+    }
 
-	/**
-	 * @return array
-	 */
-	private function & getDefaultSession()
-	{
-		// start default
-		if (!session_id()) {
-			if (isset($this->config['_sessionLifetime'])) {
-				ini_set('session.gc_maxlifetime', $this->config['_sessionLifetime'] * 60);
-			}
+    /**
+     * @return array
+     */
+    private function & getDefaultSession()
+    {
+        // start default
+        if (!session_id()) {
+            if (isset($this->config['_sessionLifetime'])) {
+                ini_set('session.gc_maxlifetime', $this->config['_sessionLifetime'] * 60);
+            }
 
-			if (isset($this->config['_sessionDir'])) {
-				ini_set('session.save_path', $this->config['_sessionDir']);
-			}
+            if (isset($this->config['_sessionDir'])) {
+                ini_set('session.save_path', $this->config['_sessionDir']);
+            }
 
-			if (isset($this->config['_sessionDomain'])) {
-				ini_set('session.cookie_domain', $this->config['_sessionDomain']);
-			}
+            if (isset($this->config['_sessionDomain'])) {
+                ini_set('session.cookie_domain', $this->config['_sessionDomain']);
+            }
 
-			session_start();
-		}
+            session_start();
+        }
 
-		return $_SESSION;
-	}
+        return $_SESSION;
+    }
 
-	/***/
-	private function initConfig()
-	{
-		foreach ($this->session as $key => $val) {
-			if ((substr($key, 0, 1) != "_") && isset($this->config[$key])) {
-				$this->config[$key] = $val;
-			}
-		}
-	}
+    /***/
+    private function initConfig()
+    {
+        foreach ($this->session as $key => $val) {
+            if ((substr($key, 0, 1) != "_") && isset($this->config[$key])) {
+                $this->config[$key] = $val;
+            }
+        }
+    }
 
 }

--- a/core/class/uploader.php
+++ b/core/class/uploader.php
@@ -108,45 +108,12 @@ class uploader {
             $this->file = &$_FILES[key($_FILES)];
 
         // LOAD DEFAULT CONFIGURATION
-        require "conf/config.php";
+        $config = require "conf/config.php";
 
-        // SETTING UP SESSION
-        if (!session_id()) {
-            if (isset($_CONFIG['_sessionLifetime']))
-                ini_set('session.gc_maxlifetime', $_CONFIG['_sessionLifetime'] * 60);
-            if (isset($_CONFIG['_sessionDir']))
-                ini_set('session.save_path', $_CONFIG['_sessionDir']);
-            if (isset($_CONFIG['_sessionDomain']))
-                ini_set('session.cookie_domain', $_CONFIG['_sessionDomain']);
-            session_start();
-        }
-
-        // LOAD SESSION CONFIGURATION IF EXISTS
-        $this->config = $_CONFIG;
-        $sessVar = "_sessionVar";
-        if (isset($_CONFIG[$sessVar])) {
-
-            $sessVar = $_CONFIG[$sessVar];
-
-            if (!isset($_SESSION[$sessVar]))
-                $_SESSION[$sessVar] = array();
-
-            $sessVar = &$_SESSION[$sessVar];
-
-            if (!is_array($sessVar))
-                $sessVar = array();
-
-            foreach ($sessVar as $key => $val)
-                if ((substr($key, 0, 1) != "_") && isset($_CONFIG[$key]))
-                    $this->config[$key] = $val;
-
-            if (!isset($sessVar['self']))
-                $sessVar['self'] = array();
-
-            $this->session = &$sessVar['self'];
-
-        } else
-            $this->session = &$_SESSION;
+        // SETTING UP SESSION & CONFIG
+		$session = new session($config);
+		$this->session = $session->getSession();
+		$this->config = $session->getConfig();
 
         // SECURING THE SESSION
         $stamp = array(

--- a/core/class/uploader.php
+++ b/core/class/uploader.php
@@ -111,9 +111,9 @@ class uploader {
         $config = require "conf/config.php";
 
         // SETTING UP SESSION & CONFIG
-		$session = new session($config);
-		$this->session = $session->getSession();
-		$this->config = $session->getConfig();
+        $session = new session($config);
+        $this->session = $session->getSession();
+        $this->config = $session->getConfig();
 
         // SECURING THE SESSION
         $stamp = array(


### PR DESCRIPTION
1) I've moved session init to separate class (out of uploader.php) because I think that starting and managing of session is not in uploader's responsibility.

**Important:** `return $_CONFIG;` at the end of `config.php` file is necessary. I think that use of `$config = require 'conf/config.php';` is better and more clear than `require 'conf/config.php'; $something = $_CONFIG['key']`.

2) It still supports "session key" definition in the config file but now also `\Iterator` objects or clean arrays.

So we can set `_sessionVar` in the config like `KCFINDER` and `SESSION['KCFINDER']` will be used.

But we can also set `$someObject` as value of `_sessionVar`. Then this object will be used for sessions.
It's very useful for better session control for example with frameworks. In this case, KCFinder won't start session and won't access `$_SESSION` super global variable directly. It will access via given object from config.
