### PR TITLE
Filename normalize rules & behavior changed

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -122,5 +122,3 @@ $_CONFIG = array(
     //'_jsMinCmd' => "java -jar /path/to/yuicompressor.jar --type js {file}",
 
 );
-
-?>

--- a/conf/config.php
+++ b/conf/config.php
@@ -108,7 +108,7 @@ $_CONFIG = array(
 
 // THE FOLLOWING SETTINGS CANNOT BE OVERRIDED WITH SESSION SETTINGS
 
-    '_normalizeFilenames' => false,
+    '_normalizeFilenames' => true,
     '_check4htaccess' => true,
     //'_tinyMCEPath' => "/tiny_mce",
 

--- a/core/class/uploader.php
+++ b/core/class/uploader.php
@@ -411,17 +411,7 @@ class uploader {
     }
 
     protected function checkFilename($file) {
-
-        if ((basename($file) !== $file) ||
-            (
-                isset($this->config['_normalizeFilenames']) &&
-                $this->config['_normalizeFilenames'] &&
-                preg_match('/[^0-9a-z\.\- _]/si', $file)
-            )
-        )
-            return false;
-
-        return true;
+		return (basename($file) === $file);
     }
 
     protected function checkUploadedFile(array $aFile=null) {

--- a/core/class/uploader.php
+++ b/core/class/uploader.php
@@ -411,7 +411,7 @@ class uploader {
     }
 
     protected function checkFilename($file) {
-		return (basename($file) === $file);
+        return (basename($file) === $file);
     }
 
     protected function checkUploadedFile(array $aFile=null) {

--- a/lib/helper_file.php
+++ b/lib/helper_file.php
@@ -198,18 +198,70 @@ class file {
                 : basename($file));
     }
 
-/** Normalize given filename. Accented characters becomes non-accented and
-  * removes any other special characters. Usable for non-unicode filesystems
-  * @param $filename
-  * @return string */
-
-    static function normalizeFilename($filename) {
-        $string = htmlentities($filename, ENT_QUOTES, 'UTF-8');
-        if (strpos($string, '&') !== false)
-            $filename = html_entity_decode(preg_replace('~&([a-z]{1,2})(?:acute|cedil|circ|grave|lig|orn|ring|slash|tilde|uml);~i', '$1', $string), ENT_QUOTES, 'UTF-8');
-        $filename = trim(preg_replace('~[^0-9a-z\.\- ]~i', "_", $filename));
-        return $filename;
+	/**
+	 * Normalize given filename. Accented characters becomes non-accented and
+	 * removes any other special characters. Usable for non-unicode filesystems
+	 *
+	 * @param $filename
+	 * @return string
+	 */
+	public static function normalizeFilename($filename) {
+		return self::webalize($filename, '.');
     }
+
+	/**
+	 * Converts to web safe characters [a-z0-9-] text.
+	 *
+	 * This function is derived from code of the Nette Framework (2014-07-31) (http://nette.org),
+	 * which is subject to the new BSD license (http://nette.org/en/license).
+	 * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+	 *
+	 * @param string $s UTF-8 encoding
+	 * @param string $charlist allowed characters
+	 * @param bool $lower
+	 * @return string
+	 */
+	public static function webalize($s, $charlist = NULL, $lower = TRUE)
+	{
+		$s = self::toAscii($s);
+		if ($lower) {
+			$s = strtolower($s);
+		}
+		$s = preg_replace('#[^a-z0-9' . preg_quote($charlist, '#') . ']+#i', '-', $s);
+		$s = trim($s, '-');
+		return $s;
+	}
+
+	/**
+	 * Converts to ASCII.
+	 *
+	 * This function is derived from code of the Nette Framework (2014-07-31) (http://nette.org),
+	 * which is subject to the new BSD license (http://nette.org/en/license).
+	 * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+	 *
+	 * @param string $s UTF-8 encoding
+	 * @return string ASCII
+	 */
+	public static function toAscii($s)
+	{
+		$s = preg_replace('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{2FF}\x{370}-\x{10FFFF}]#u', '', $s);
+		$s = strtr($s, '`\'"^~', "\x01\x02\x03\x04\x05");
+		$s = str_replace(array("\xE2\x80\x9E", "\xE2\x80\x9C", "\xE2\x80\x9D", "\xE2\x80\x9A",
+				"\xE2\x80\x98", "\xE2\x80\x99", "\xC2\xBB", "\xC2\xAB"),
+			array("\x03", "\x03", "\x03", "\x02", "\x02", "\x02", ">>", "<<"), $s);
+		if (ICONV_IMPL === 'glibc') {
+			$s = @iconv('UTF-8', 'WINDOWS-1250//TRANSLIT', $s); // intentionally @
+			$s = strtr($s, "\xa5\xa3\xbc\x8c\xa7\x8a\xaa\x8d\x8f\x8e\xaf\xb9\xb3\xbe\x9c\x9a\xba\x9d\x9f\x9e"
+				. "\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3"
+				. "\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8"
+				. "\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf8\xf9\xfa\xfb\xfc\xfd\xfe\x96",
+				"ALLSSSSTZZZallssstzzzRAAAALCCCEEEEIIDDNNOOOOxRUUUUYTsraaaalccceeeeiiddnnooooruuuuyt-");
+		} else {
+			$s = @iconv('UTF-8', 'ASCII//TRANSLIT', $s); // intentionally @
+		}
+		$s = str_replace(array('`', "'", '"', '^', '~'), '', $s);
+		return strtr($s, "\x01\x02\x03\x04\x05", '`\'"^~');
+	}
 
 }
 

--- a/lib/helper_file.php
+++ b/lib/helper_file.php
@@ -198,71 +198,70 @@ class file {
                 : basename($file));
     }
 
-	/**
-	 * Normalize given filename. Accented characters becomes non-accented and
-	 * removes any other special characters. Usable for non-unicode filesystems
-	 *
-	 * @param $filename
-	 * @return string
-	 */
-	public static function normalizeFilename($filename) {
-		return self::webalize($filename, '.');
+    /**
+     * Normalize given filename. Accented characters becomes non-accented and
+     * removes any other special characters. Usable for non-unicode filesystems
+     *
+     * @param $filename
+     * @return string
+     */
+    public static function normalizeFilename($filename)
+    {
+        return self::webalize($filename, '.');
     }
 
-	/**
-	 * Converts to web safe characters [a-z0-9-] text.
-	 *
-	 * This function is derived from code of the Nette Framework (2014-07-31) (http://nette.org),
-	 * which is subject to the new BSD license (http://nette.org/en/license).
-	 * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
-	 *
-	 * @param string $s UTF-8 encoding
-	 * @param string $charlist allowed characters
-	 * @param bool $lower
-	 * @return string
-	 */
-	public static function webalize($s, $charlist = NULL, $lower = TRUE)
-	{
-		$s = self::toAscii($s);
-		if ($lower) {
-			$s = strtolower($s);
-		}
-		$s = preg_replace('#[^a-z0-9' . preg_quote($charlist, '#') . ']+#i', '-', $s);
-		$s = trim($s, '-');
-		return $s;
-	}
+    /**
+     * Converts to web safe characters [a-z0-9-] text.
+     *
+     * This function is derived from code of the Nette Framework (2014-07-31) (http://nette.org),
+     * which is subject to the new BSD license (http://nette.org/en/license).
+     * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+     *
+     * @param string $s UTF-8 encoding
+     * @param string $charlist allowed characters
+     * @param bool $lower
+     * @return string
+     */
+    public static function webalize($s, $charlist = NULL, $lower = TRUE)
+    {
+        $s = self::toAscii($s);
+        if ($lower) {
+            $s = strtolower($s);
+        }
+        $s = preg_replace('#[^a-z0-9' . preg_quote($charlist, '#') . ']+#i', '-', $s);
+        $s = trim($s, '-');
+        return $s;
+    }
 
-	/**
-	 * Converts to ASCII.
-	 *
-	 * This function is derived from code of the Nette Framework (2014-07-31) (http://nette.org),
-	 * which is subject to the new BSD license (http://nette.org/en/license).
-	 * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
-	 *
-	 * @param string $s UTF-8 encoding
-	 * @return string ASCII
-	 */
-	public static function toAscii($s)
-	{
-		$s = preg_replace('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{2FF}\x{370}-\x{10FFFF}]#u', '', $s);
-		$s = strtr($s, '`\'"^~', "\x01\x02\x03\x04\x05");
-		$s = str_replace(array("\xE2\x80\x9E", "\xE2\x80\x9C", "\xE2\x80\x9D", "\xE2\x80\x9A",
-				"\xE2\x80\x98", "\xE2\x80\x99", "\xC2\xBB", "\xC2\xAB"),
-			array("\x03", "\x03", "\x03", "\x02", "\x02", "\x02", ">>", "<<"), $s);
-		if (ICONV_IMPL === 'glibc') {
-			$s = @iconv('UTF-8', 'WINDOWS-1250//TRANSLIT', $s); // intentionally @
-			$s = strtr($s, "\xa5\xa3\xbc\x8c\xa7\x8a\xaa\x8d\x8f\x8e\xaf\xb9\xb3\xbe\x9c\x9a\xba\x9d\x9f\x9e"
-				. "\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3"
-				. "\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8"
-				. "\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf8\xf9\xfa\xfb\xfc\xfd\xfe\x96",
-				"ALLSSSSTZZZallssstzzzRAAAALCCCEEEEIIDDNNOOOOxRUUUUYTsraaaalccceeeeiiddnnooooruuuuyt-");
-		} else {
-			$s = @iconv('UTF-8', 'ASCII//TRANSLIT', $s); // intentionally @
-		}
-		$s = str_replace(array('`', "'", '"', '^', '~'), '', $s);
-		return strtr($s, "\x01\x02\x03\x04\x05", '`\'"^~');
-	}
+    /**
+     * Converts to ASCII.
+     *
+     * This function is derived from code of the Nette Framework (2014-07-31) (http://nette.org),
+     * which is subject to the new BSD license (http://nette.org/en/license).
+     * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+     *
+     * @param string $s UTF-8 encoding
+     * @return string ASCII
+     */
+    public static function toAscii($s)
+    {
+        $s = preg_replace('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{2FF}\x{370}-\x{10FFFF}]#u', '', $s);
+        $s = strtr($s, '`\'"^~', "\x01\x02\x03\x04\x05");
+        $s = str_replace(array("\xE2\x80\x9E", "\xE2\x80\x9C", "\xE2\x80\x9D", "\xE2\x80\x9A",
+                "\xE2\x80\x98", "\xE2\x80\x99", "\xC2\xBB", "\xC2\xAB"),
+            array("\x03", "\x03", "\x03", "\x02", "\x02", "\x02", ">>", "<<"), $s);
+        if (ICONV_IMPL === 'glibc') {
+            $s = @iconv('UTF-8', 'WINDOWS-1250//TRANSLIT', $s); // intentionally @
+            $s = strtr($s, "\xa5\xa3\xbc\x8c\xa7\x8a\xaa\x8d\x8f\x8e\xaf\xb9\xb3\xbe\x9c\x9a\xba\x9d\x9f\x9e"
+                . "\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3"
+                . "\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8"
+                . "\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf8\xf9\xfa\xfb\xfc\xfd\xfe\x96",
+                "ALLSSSSTZZZallssstzzzRAAAALCCCEEEEIIDDNNOOOOxRUUUUYTsraaaalccceeeeiiddnnooooruuuuyt-");
+        } else {
+            $s = @iconv('UTF-8', 'ASCII//TRANSLIT', $s); // intentionally @
+        }
+        $s = str_replace(array('`', "'", '"', '^', '~'), '', $s);
+        return strtr($s, "\x01\x02\x03\x04\x05", '`\'"^~');
+    }
 
 }
-
-?>


### PR DESCRIPTION
I think that `_normalizeFilenames` should be turned on by default because user shouldn't create invalid file and directory names.

I changed behavior of normalizer like this:
- `uploader::checkFilename()` doesn't check for regexp -> when we change normalizing function, the previous implementation of `checkFilename` had own rules and caused problems even when filename had right format given by normalizing funcion. I think it's normalizer response.
- `file::normalizeFilename()` uses more robust and better implementation derived from [Nette Framework](http://nette.org) 
  - it translates all names to URL-friendly format, the previous implementation failed eg. on czech diacritics
  - eg. "nová složka" from user's input will be saved now as "nova-slozka" (URL-friendly)
