### PR TITLE
custom config file support (eg. for bower support)

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -16,6 +16,13 @@
    even if you are using session configuration.
    See http://kcfinder.sunhater.com/install for setting descriptions */
 
+// custom config file support (eg. for bower support)
+$customConfig = __DIR__ . '/../../kcfinder-config.php';
+if (is_file($customConfig)) {
+    return require_once $customConfig;
+}
+
+
 $_CONFIG = array(
 
 


### PR DESCRIPTION
I don't have included KCFinder in every GIT repository, I like add it like other dependencies (using Composer for PHP or Bower for JS/CSS).

Because KCFinder is combination of both and is used over HTTP, I've added it via Bower.
However I need custom PHP config and I have two ways:
- fork a repository of KCFinder for each config
- enable config PHP file outside the KCFinder repo

I like the second option, so I've made a conditional `require` inside `conf/config.php`.
Now when I install KCFinder via bower, I can create custom script `kcfinder-config.php` in the root of bower libraries and everything works fine, is customized and I don't need new repositories of KCFinder for each project where I use it :)
