### PR TITLE
Added ability to pass config manually

### DIFF
--- a/core/autoload.php
+++ b/core/autoload.php
@@ -21,13 +21,15 @@ spl_autoload_register(function($path) {
     list($ns, $class) = $path;
 
     if ($ns == "kcfinder") {
+        $dir = dirname(__FILE__);
+
         if (in_array($class, array("uploader", "browser", "minifier", "session")))
-            require "core/class/$class.php";
-        elseif (file_exists("core/types/$class.php"))
-            require "core/types/$class.php";
-        elseif (file_exists("lib/class_$class.php"))
-            require "lib/class_$class.php";
-        elseif (file_exists("lib/helper_$class.php"))
-            require "lib/helper_$class.php";
+            require $dir . "/../core/class/$class.php";
+        elseif (file_exists($dir . "/../core/types/$class.php"))
+            require $dir . "/../core/types/$class.php";
+        elseif (file_exists($dir . "/../lib/class_$class.php"))
+            require $dir . "/../lib/class_$class.php";
+        elseif (file_exists($dir . "/../lib/helper_$class.php"))
+            require $dir . "/../lib/helper_$class.php";
     }
 });

--- a/core/class/browser.php
+++ b/core/class/browser.php
@@ -19,8 +19,8 @@ class browser extends uploader {
     protected $thumbsDir;
     protected $thumbsTypeDir;
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct($config = array()) {
+        parent::__construct($config);
 
         // SECURITY CHECK INPUT DIRECTORY
         if (isset($_POST['dir'])) {
@@ -691,10 +691,10 @@ class browser extends uploader {
     protected function sendDefaultThumb($file=null) {
         if ($file !== null) {
             $ext = file::getExtension($file);
-            $thumb = "themes/{$this->config['theme']}/img/files/big/$ext.png";
+            $thumb = dirname(__FILE__) . "/../../themes/{$this->config['theme']}/img/files/big/$ext.png";
         }
         if (!isset($thumb) || !file_exists($thumb))
-            $thumb = "themes/{$this->config['theme']}/img/files/big/..png";
+            $thumb = dirname(__FILE__) . "/../../themes/{$this->config['theme']}/img/files/big/..png";
         header("Content-Type: image/png");
         readfile($thumb);
         die;
@@ -734,8 +734,8 @@ class browser extends uploader {
             if ($stat === false) continue;
             $name = basename($file);
             $ext = file::getExtension($file);
-            $bigIcon = file_exists("themes/{$this->config['theme']}/img/files/big/$ext.png");
-            $smallIcon = file_exists("themes/{$this->config['theme']}/img/files/small/$ext.png");
+            $bigIcon = file_exists(dirname(__FILE__) . "/../../themes/{$this->config['theme']}/img/files/big/$ext.png");
+            $smallIcon = file_exists(dirname(__FILE__) . "/../../themes/{$this->config['theme']}/img/files/small/$ext.png");
             $thumb = file_exists("$thumbDir/$name");
             $return[] = array(
                 'name' => stripcslashes($name),
@@ -857,14 +857,14 @@ class browser extends uploader {
         if ($template === null)
             $template = $this->action;
 
-        if (file_exists("tpl/tpl_$template.php")) {
+        if (file_exists(dirname(__FILE__) . "/../../tpl/tpl_$template.php")) {
             ob_start();
             $eval = "unset(\$data);unset(\$template);unset(\$eval);";
             $_ = $data;
             foreach (array_keys($data) as $key)
                 if (preg_match('/^[a-z\d_]+$/i', $key))
                     $eval .= "\$$key=\$_['$key'];";
-            $eval .= "unset(\$_);require \"tpl/tpl_$template.php\";";
+            $eval .= "unset(\$_);require dirname(__FILE__) . \"/../../tpl/tpl_$template.php\";";
             eval($eval);
             return ob_get_clean();
         }
@@ -915,7 +915,7 @@ class browser extends uploader {
         if (isset($this->session['langs']))
             return $this->session['langs'];
 
-        $files = dir::content("lang", array(
+        $files = dir::content(dirname(__FILE__) . "/../../lang", array(
             'pattern' => '/^[a-z]{2,3}(\-[a-z]{2})?\.php$/',
             'types' => "file"
         ));

--- a/core/class/session.php
+++ b/core/class/session.php
@@ -20,13 +20,13 @@ class session {
     public $values;
     protected $config;
 
-    public function __construct($configFile) {
+    public function __construct($configFile, $config) {
 
         // Start session if it is not already started
         if (!session_id())
             session_start();
 
-        $config = require($configFile);
+        $config = $config + require($configFile);
 
         // _sessionVar option is set
         if (isset($config[self::SESSION_VAR])) {

--- a/core/class/uploader.php
+++ b/core/class/uploader.php
@@ -94,7 +94,7 @@ class uploader {
         return property_exists($this, $property) ? $this->$property : null;
     }
 
-    public function __construct() {
+    public function __construct($config = array()) {
 
         // SET CMS INTEGRATION PROPERTY
         if (isset($_GET['cms']) &&
@@ -103,12 +103,12 @@ class uploader {
         )
             $this->cms = $_GET['cms'];
 
-		// LINKING UPLOADED FILE
+        // LINKING UPLOADED FILE
         if (count($_FILES))
             $this->file = &$_FILES[key($_FILES)];
 
         // CONFIG & SESSION SETUP
-        $session = new session("conf/config.php");
+        $session = new session(dirname(__FILE__) . "/../../conf/config.php", $config);
         $this->config = $session->getConfig();
         $this->session = &$session->values;
 
@@ -221,7 +221,7 @@ class uploader {
         foreach ($this->langInputNames as $key)
             if (isset($_GET[$key]) &&
                 preg_match('/^[a-z][a-z\._\-]*$/i', $_GET[$key]) &&
-                file_exists("lang/" . strtolower($_GET[$key]) . ".php")
+                file_exists(dirname(__FILE__) . "/../../lang/" . strtolower($_GET[$key]) . ".php")
             ) {
                 $this->lang = $_GET[$key];
                 break;
@@ -655,7 +655,7 @@ class uploader {
     }
 
     protected function localize($langCode) {
-        require "lang/{$langCode}.php";
+        require dirname(__FILE__) . "/../../lang/{$langCode}.php";
         setlocale(LC_ALL, $lang['_locale']);
         $this->charset = $lang['_charset'];
         $this->dateTimeFull = $lang['_dateTimeFull'];
@@ -761,6 +761,6 @@ if (window.opener) window.close();
     }
 
     protected function get_htaccess() {
-        return file_get_contents("conf/upload.htaccess");
+        return file_get_contents(dirname(__FILE__) . "/../../conf/upload.htaccess");
     }
 }

--- a/js/080.files.js
+++ b/js/080.files.js
@@ -59,7 +59,7 @@ _.showFiles = function(callBack, selected) {
                     icon = ".image";
                 else if (!icon.length || !file.smallIcon)
                     icon = ".";
-                icon = "themes/" + _.theme + "/img/files/small/" + icon + ".png";
+                icon = _.baseUrl + "themes/" + _.theme + "/img/files/small/" + icon + ".png";
 
                 f = $('<tr class="file"><td class="name thumb"></td><td class="time"></td><td class="size"></td></tr>');
                 f.appendTo(c.find('table'));
@@ -74,7 +74,7 @@ _.showFiles = function(callBack, selected) {
                 } else {
                     icon = file.bigIcon ? $.$.getFileExtension(file.name) : ".";
                     if (!icon.length) icon = ".";
-                    icon = "themes/" + _.theme + "/img/files/big/" + icon + ".png";
+                    icon = _.baseUrl + "themes/" + _.theme + "/img/files/big/" + icon + ".png";
                 }
                 f = $('<div class="file"><div class="thumb"></div><div class="name"></div><div class="time"></div><div class="size"></div></div>');
                 f.appendTo(c);

--- a/tpl/tpl_browser.php
+++ b/tpl/tpl_browser.php
@@ -3,8 +3,8 @@
 <head>
 <title>KCFinder: /<?php echo $this->session['dir'] ?></title>
 <link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
-<?php INCLUDE "tpl/tpl_css.php" ?>
-<?php INCLUDE "tpl/tpl_javascript.php" ?>
+<?php INCLUDE dirname(__FILE__) . "/tpl_css.php" ?>
+<?php INCLUDE dirname(__FILE__) . "/tpl_javascript.php" ?>
 </head>
 <body>
 <div id="resizer"></div>

--- a/tpl/tpl_css.php
+++ b/tpl/tpl_css.php
@@ -1,6 +1,6 @@
-<link href="css/index.php" rel="stylesheet" type="text/css" />
+<link href="<?php echo $this->config['baseUrl'] ?>css/index.php" rel="stylesheet" type="text/css" />
 <style type="text/css">
 div.file{width:<?php echo $this->config['thumbWidth'] ?>px;}
 div.file .thumb{width:<?php echo $this->config['thumbWidth'] ?>px;height:<?php echo $this->config['thumbHeight'] ?>px}
 </style>
-<link href="themes/<?php echo $this->config['theme'] ?>/css.php" rel="stylesheet" type="text/css" />
+<link href="<?php echo $this->config['baseUrl'] ?>themes/<?php echo $this->config['theme'] ?>/css.php" rel="stylesheet" type="text/css" />

--- a/tpl/tpl_javascript.php
+++ b/tpl/tpl_javascript.php
@@ -1,8 +1,8 @@
 <?php
     NAMESPACE kcfinder;
 ?>
-<script src="js/index.php" type="text/javascript"></script>
-<script src="js_localize.php?lng=<?php echo $this->lang ?>" type="text/javascript"></script>
+<script src="<?php echo $this->config['baseUrl'] ?>js/index.php" type="text/javascript"></script>
+<script src="<?php echo $this->config['baseUrl'] ?>js_localize.php?lng=<?php echo $this->lang ?>" type="text/javascript"></script>
 <?php
     IF ($this->opener['name'] == "tinymce"):
 ?>
@@ -12,7 +12,7 @@
 
     IF (file_exists("themes/{$this->config['theme']}/js.php")):
 ?>
-<script src="themes/<?php echo $this->config['theme'] ?>/js.php" type="text/javascript"></script>
+<script src="<?php echo $this->config['baseUrl'] ?>themes/<?php echo $this->config['theme'] ?>/js.php" type="text/javascript"></script>
 <?php
     ENDIF;
 ?>
@@ -31,6 +31,7 @@ _.opener = <?php echo json_encode($this->opener) ?>;
 _.cms = "<?php echo text::jsValue($this->cms) ?>";
 _.dropUploadMaxFilesize = <?php echo isset($this->config['_dropUploadMaxFilesize']) ? intVal($this->config['_dropUploadMaxFilesize']) : "10485760" ?>;
 _.langs = <?= json_encode($this->getLangs()) ?>;
+_.baseUrl = "<?php echo text::jsValue($this->config['baseUrl']) ?>";
 $.$.kuki.domain = "<?php echo text::jsValue($this->config['cookieDomain']) ?>";
 $.$.kuki.path = "<?php echo text::jsValue($this->config['cookiePath']) ?>";
 $.$.kuki.prefix = "<?php echo text::jsValue($this->config['cookiePrefix']) ?>";


### PR DESCRIPTION
Personally I don't like the configuration via session thing. Instead I want to have my own logic in my app that would check privileges and such and then call the KCFinder directly. Here is what I use in my project:

``` php
<?php

use kcfinder\browser;
use kcfinder\uploader;

class FileManagerPresenter extends BasePresenter
{

    public function actionBrowse()
    {
        require_once $this->wwwDir . '/support/kcfinder/core/autoload.php';
        $browser = new browser($this->getConfig());
        $browser->action();
    }

    public function actionUpload()
    {
        require_once $this->wwwDir . '/support/kcfinder/core/autoload.php';
        $uploader = new uploader($this->getConfig());
        $uploader->upload();
    }

    private function getConfig()
    {
        // some logic to put the desired config together
    }

}
```

Now this means that the constructor should accept configuration array as an optional argument.

As a sideeffect since I have different URL it breaks autoloading, searching for lang files, javascript, css and such. I have fixed all that as well.
