### PR TITLE
Adds recursive mkdir permission to config and uploader

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -66,6 +66,7 @@ return array(
 
     'dirPerms' => 0755,
     'filePerms' => 0644,
+    'allowRecursiveDirCreate' => false,
 
     'access' => array(
 

--- a/core/class/uploader.php
+++ b/core/class/uploader.php
@@ -233,7 +233,7 @@ class uploader {
 
             // TRY TO CREATE UPLOAD DIRECTORY IF NOT EXISTS
             if (!$this->config['disabled'] && !is_dir($this->config['uploadDir']))
-                @mkdir($this->config['uploadDir'], $this->config['dirPerms']);
+                @mkdir($this->config['uploadDir'], $this->config['dirPerms'], $this->config['allowRecursiveDirCreate']);
 
             // CHECK & MAKE DEFAULT .htaccess
             if (isset($this->config['_check4htaccess']) &&


### PR DESCRIPTION
Since kcfinder allows dynamic upload directory select, some users may want o create upload folder just in upload time. This commit create a new config rule name 'allowRecursiveDirCreate' which is allows this process if it is set as 'true'.
