### PR TITLE
KcFinder 2.x fix for broken thumbnails when file/folder contains single quotes

### DIFF
--- a/js/browser/files.js
+++ b/js/browser/files.js
@@ -83,6 +83,8 @@ browser.showFiles = function(callBack, selected) {
                     if (!icon.length) icon = '.';
                     icon = 'themes/' + browser.theme + '/img/files/big/' + icon + '.png';
                 }
+                // The icon URL will fail if the file or folder contains single quotes, so we'll escape them here
+                icon = icon.replace(/'/g, "\\'");
                 html += '<div class="file">' +
                     '<div class="thumb" style="background-image:url(\'' + icon + '\')" ></div>' +
                     '<div class="name">' + _.htmlData(file.name) + '</div>' +


### PR DESCRIPTION
I found that in 2.x the thumbnails were broken when a folder contained a single quote. This appears to fix the problem.

Not sure if this problem exists in 3.x too, have not tested.
