### PR TITLE
fix checking file path for empty type (for thumbnails to work)

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -112,6 +112,7 @@ return array(
     '_check4htaccess' => true,
     '_normalizeFilenames' => false,
     '_dropUploadMaxFilesize' => 10485760,
+    '_appendUniqueSuffixOnOverwrite' => true,	// If it is set to true files will not be overwritten and instead (upon coflict) a numeric suffix will be appended to uploaded file name.
     //'_tinyMCEPath' => "/tiny_mce",
     //'_cssMinCmd' => "java -jar /path/to/yuicompressor.jar --type css {file}",
     //'_jsMinCmd' => "java -jar /path/to/yuicompressor.jar --type js {file}",

--- a/core/class/browser.php
+++ b/core/class/browser.php
@@ -673,7 +673,10 @@ class browser extends uploader {
         }
 
         $filename = $this->normalizeFilename($file['name']);
-        $target = "$dir/" . file::getInexistantFilename($filename, $dir);
+        if (isset($this->config['_appendUniqueSuffixOnOverwrite']) && $this->config['_appendUniqueSuffixOnOverwrite']) {
+            $filename = file::getInexistantFilename($filename, $dir);
+        }
+        $target = "$dir/$filename";
 
         if (!@move_uploaded_file($file['tmp_name'], $target) &&
             !@rename($file['tmp_name'], $target) &&

--- a/core/class/uploader.php
+++ b/core/class/uploader.php
@@ -103,7 +103,7 @@ class uploader {
         )
             $this->cms = $_GET['cms'];
 
-		// LINKING UPLOADED FILE
+        // LINKING UPLOADED FILE
         if (count($_FILES))
             $this->file = &$_FILES[key($_FILES)];
 
@@ -358,7 +358,9 @@ class uploader {
         $rPath = realpath($file);
         if (strtoupper(substr(PHP_OS, 0, 3)) == "WIN")
             $rPath = str_replace("\\", "/", $rPath);
-        return (substr($rPath, 0, strlen($this->typeDir)) === $this->typeDir);
+        $rPath = rtrim($rPath, '/') . '/';
+        $baseDir = rtrim($this->typeDir, '/') . '/';
+        return (substr($rPath, 0, strlen($baseDir)) === $baseDir);
     }
 
     protected function checkFilename($file) {

--- a/core/class/uploader.php
+++ b/core/class/uploader.php
@@ -369,7 +369,7 @@ class uploader {
             (
                 isset($this->config['_normalizeFilenames']) &&
                 $this->config['_normalizeFilenames'] &&
-                preg_match('/[^0-9a-z\.\- _]/si', $file)
+                preg_match('/[^0-9a-z\.\- _\(\)]/si', $file)	// note `(1)` is added to file name when preventing overwrite
             )
         )
             return false;

--- a/lib/helper_dir.php
+++ b/lib/helper_dir.php
@@ -95,7 +95,7 @@ class dir {
             'types' => "all",   // Allowed: "all" or possible return values
                                 // of filetype(), or an array with them
             'addPath' => true,  // Whether to add directory path to filenames
-            'pattern' => '/./', // Regular expression pattern for filename
+            'pattern' => '/^[^\.].+/', // Regular expression pattern for filename -- by default don't show hidden files
             'followLinks' => true
         );
 


### PR DESCRIPTION
Types config to reproduce problem:

```
    'types' => array(
        ''  =>  "*img",
    ),
```

With this config (at least on Windows) thumbnails will not appear in browser. This is because `checkFilePath` will fail due to difference in trailing `/` in `$rPath` vs `$this->typeDir`.
